### PR TITLE
feat: add recovery status message

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -42,6 +42,8 @@ class _MyAppState extends State<MyApp> {
   bool recoverFederations = false;
 
   String _recoveryStatus = "Retrieving federation backup from Nostr...";
+  Timer? _recoveryTimer;
+  int _recoverySecondsRemaining = 30;
 
   @override
   void initState() {
@@ -90,11 +92,28 @@ class _MyAppState extends State<MyApp> {
           ),
         );
       } else if (event is MultimintEvent_NostrRecovery) {
+        _startOrResetRecoveryTimer();
         setState(() {
           _recoveryStatus =
               "Trying to re-join ${event.field0} using peer ${event.field1}...";
         });
       }
+    });
+  }
+
+  void _startOrResetRecoveryTimer() {
+    _recoveryTimer?.cancel();
+    setState(() {
+      _recoverySecondsRemaining = 30;
+    });
+
+    _recoveryTimer = Timer.periodic(Duration(seconds: 1), (timer) {
+      if (_recoverySecondsRemaining <= 1) {
+        timer.cancel();
+      }
+      setState(() {
+        _recoverySecondsRemaining--;
+      });
     });
   }
 
@@ -170,6 +189,7 @@ class _MyAppState extends State<MyApp> {
   @override
   void dispose() {
     _subscription.cancel();
+    _recoveryTimer?.cancel();
     super.dispose();
   }
 
@@ -245,9 +265,24 @@ class _MyAppState extends State<MyApp> {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                CircularProgressIndicator(),
-                SizedBox(height: 16),
-                Text(_recoveryStatus, style: TextStyle(fontSize: 16)),
+                const CircularProgressIndicator(),
+                const SizedBox(height: 16),
+                Text(
+                  _recoveryStatus,
+                  style: const TextStyle(fontSize: 16),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 16),
+                if (_recoverySecondsRemaining <= 15)
+                  Text(
+                    "Peer might be offline, trying for $_recoverySecondsRemaining more seconds...",
+                    style: const TextStyle(
+                      fontSize: 16,
+                      color: Colors.red,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
               ],
             ),
           );

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -92,11 +92,20 @@ class _MyAppState extends State<MyApp> {
           ),
         );
       } else if (event is MultimintEvent_NostrRecovery) {
-        _startOrResetRecoveryTimer();
-        setState(() {
-          _recoveryStatus =
-              "Trying to re-join ${event.field0} using peer ${event.field1}...";
-        });
+        if (event.field2 != null) {
+          ToastService().show(
+            message: "Joined ${event.field2!.federationName}. Recovering...",
+            duration: const Duration(seconds: 5),
+            onTap: () {},
+            icon: Icon(Icons.info),
+          );
+        } else {
+          _startOrResetRecoveryTimer();
+          setState(() {
+            _recoveryStatus =
+                "Trying to re-join ${event.field0} using peer ${event.field1}...";
+          });
+        }
       }
     });
   }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -41,6 +41,8 @@ class _MyAppState extends State<MyApp> {
 
   bool recoverFederations = false;
 
+  String _recoveryStatus = "Retrieving federation backup from Nostr...";
+
   @override
   void initState() {
     super.initState();
@@ -87,6 +89,11 @@ class _MyAppState extends State<MyApp> {
             color: Theme.of(context).colorScheme.primary,
           ),
         );
+      } else if (event is MultimintEvent_NostrRecovery) {
+        setState(() {
+          _recoveryStatus =
+              "Trying to re-join ${event.field0} using peer ${event.field1}...";
+        });
       }
     });
   }
@@ -234,16 +241,13 @@ class _MyAppState extends State<MyApp> {
         );
       } else {
         if (recoverFederations) {
-          bodyContent = const Center(
+          bodyContent = Center(
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 CircularProgressIndicator(),
                 SizedBox(height: 16),
-                Text(
-                  'Retrieving federation backup from Nostr...',
-                  style: TextStyle(fontSize: 16),
-                ),
+                Text(_recoveryStatus, style: TextStyle(fontSize: 16)),
               ],
             ),
           );

--- a/lib/frb_generated.dart
+++ b/lib/frb_generated.dart
@@ -8903,6 +8903,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         return MultimintEvent_NostrRecovery(
           dco_decode_String(raw[1]),
           dco_decode_u_16(raw[2]),
+          dco_decode_opt_box_autoadd_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationSelector(
+            raw[3],
+          ),
         );
       default:
         throw Exception("unreachable");
@@ -10776,7 +10779,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 6:
         var var_field0 = sse_decode_String(deserializer);
         var var_field1 = sse_decode_u_16(deserializer);
-        return MultimintEvent_NostrRecovery(var_field0, var_field1);
+        var var_field2 =
+            sse_decode_opt_box_autoadd_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationSelector(
+              deserializer,
+            );
+        return MultimintEvent_NostrRecovery(var_field0, var_field1, var_field2);
       default:
         throw UnimplementedError('');
     }
@@ -12694,10 +12701,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case MultimintEvent_NostrRecovery(
         field0: final field0,
         field1: final field1,
+        field2: final field2,
       ):
         sse_encode_i_32(6, serializer);
         sse_encode_String(field0, serializer);
         sse_encode_u_16(field1, serializer);
+        sse_encode_opt_box_autoadd_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationSelector(
+          field2,
+          serializer,
+        );
     }
   }
 

--- a/lib/frb_generated.dart
+++ b/lib/frb_generated.dart
@@ -8899,6 +8899,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             raw[1],
           ),
         );
+      case 6:
+        return MultimintEvent_NostrRecovery(
+          dco_decode_String(raw[1]),
+          dco_decode_u_16(raw[2]),
+        );
       default:
         throw Exception("unreachable");
     }
@@ -10768,6 +10773,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
               deserializer,
             );
         return MultimintEvent_Ecash(var_field0);
+      case 6:
+        var var_field0 = sse_decode_String(deserializer);
+        var var_field1 = sse_decode_u_16(deserializer);
+        return MultimintEvent_NostrRecovery(var_field0, var_field1);
       default:
         throw UnimplementedError('');
     }
@@ -12682,6 +12691,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           field0,
           serializer,
         );
+      case MultimintEvent_NostrRecovery(
+        field0: final field0,
+        field1: final field1,
+      ):
+        sse_encode_i_32(6, serializer);
+        sse_encode_String(field0, serializer);
+        sse_encode_u_16(field1, serializer);
     }
   }
 

--- a/lib/multimint.dart
+++ b/lib/multimint.dart
@@ -537,8 +537,11 @@ sealed class MultimintEvent with _$MultimintEvent {
   ) = MultimintEvent_RecoveryProgress;
   const factory MultimintEvent.ecash((FederationId, BigInt) field0) =
       MultimintEvent_Ecash;
-  const factory MultimintEvent.nostrRecovery(String field0, int field1) =
-      MultimintEvent_NostrRecovery;
+  const factory MultimintEvent.nostrRecovery(
+    String field0,
+    int field1, [
+    FederationSelector? field2,
+  ]) = MultimintEvent_NostrRecovery;
 }
 
 class PaymentPreview {

--- a/lib/multimint.dart
+++ b/lib/multimint.dart
@@ -537,6 +537,8 @@ sealed class MultimintEvent with _$MultimintEvent {
   ) = MultimintEvent_RecoveryProgress;
   const factory MultimintEvent.ecash((FederationId, BigInt) field0) =
       MultimintEvent_Ecash;
+  const factory MultimintEvent.nostrRecovery(String field0, int field1) =
+      MultimintEvent_NostrRecovery;
 }
 
 class PaymentPreview {

--- a/lib/multimint.freezed.dart
+++ b/lib/multimint.freezed.dart
@@ -1389,11 +1389,12 @@ as (FederationId, BigInt),
 
 
 class MultimintEvent_NostrRecovery extends MultimintEvent {
-  const MultimintEvent_NostrRecovery(this.field0, this.field1): super._();
+  const MultimintEvent_NostrRecovery(this.field0, this.field1, [this.field2]): super._();
   
 
 @override final  String field0;
  final  int field1;
+ final  FederationSelector? field2;
 
 /// Create a copy of MultimintEvent
 /// with the given fields replaced by the non-null parameter values.
@@ -1405,16 +1406,16 @@ $MultimintEvent_NostrRecoveryCopyWith<MultimintEvent_NostrRecovery> get copyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MultimintEvent_NostrRecovery&&(identical(other.field0, field0) || other.field0 == field0)&&(identical(other.field1, field1) || other.field1 == field1));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MultimintEvent_NostrRecovery&&(identical(other.field0, field0) || other.field0 == field0)&&(identical(other.field1, field1) || other.field1 == field1)&&(identical(other.field2, field2) || other.field2 == field2));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,field0,field1);
+int get hashCode => Object.hash(runtimeType,field0,field1,field2);
 
 @override
 String toString() {
-  return 'MultimintEvent.nostrRecovery(field0: $field0, field1: $field1)';
+  return 'MultimintEvent.nostrRecovery(field0: $field0, field1: $field1, field2: $field2)';
 }
 
 
@@ -1425,7 +1426,7 @@ abstract mixin class $MultimintEvent_NostrRecoveryCopyWith<$Res> implements $Mul
   factory $MultimintEvent_NostrRecoveryCopyWith(MultimintEvent_NostrRecovery value, $Res Function(MultimintEvent_NostrRecovery) _then) = _$MultimintEvent_NostrRecoveryCopyWithImpl;
 @useResult
 $Res call({
- String field0, int field1
+ String field0, int field1, FederationSelector? field2
 });
 
 
@@ -1442,11 +1443,12 @@ class _$MultimintEvent_NostrRecoveryCopyWithImpl<$Res>
 
 /// Create a copy of MultimintEvent
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? field0 = null,Object? field1 = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? field0 = null,Object? field1 = null,Object? field2 = freezed,}) {
   return _then(MultimintEvent_NostrRecovery(
 null == field0 ? _self.field0 : field0 // ignore: cast_nullable_to_non_nullable
 as String,null == field1 ? _self.field1 : field1 // ignore: cast_nullable_to_non_nullable
-as int,
+as int,freezed == field2 ? _self.field2 : field2 // ignore: cast_nullable_to_non_nullable
+as FederationSelector?,
   ));
 }
 

--- a/lib/multimint.freezed.dart
+++ b/lib/multimint.freezed.dart
@@ -1386,6 +1386,74 @@ as (FederationId, BigInt),
 }
 
 /// @nodoc
+
+
+class MultimintEvent_NostrRecovery extends MultimintEvent {
+  const MultimintEvent_NostrRecovery(this.field0, this.field1): super._();
+  
+
+@override final  String field0;
+ final  int field1;
+
+/// Create a copy of MultimintEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MultimintEvent_NostrRecoveryCopyWith<MultimintEvent_NostrRecovery> get copyWith => _$MultimintEvent_NostrRecoveryCopyWithImpl<MultimintEvent_NostrRecovery>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MultimintEvent_NostrRecovery&&(identical(other.field0, field0) || other.field0 == field0)&&(identical(other.field1, field1) || other.field1 == field1));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,field0,field1);
+
+@override
+String toString() {
+  return 'MultimintEvent.nostrRecovery(field0: $field0, field1: $field1)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $MultimintEvent_NostrRecoveryCopyWith<$Res> implements $MultimintEventCopyWith<$Res> {
+  factory $MultimintEvent_NostrRecoveryCopyWith(MultimintEvent_NostrRecovery value, $Res Function(MultimintEvent_NostrRecovery) _then) = _$MultimintEvent_NostrRecoveryCopyWithImpl;
+@useResult
+$Res call({
+ String field0, int field1
+});
+
+
+
+
+}
+/// @nodoc
+class _$MultimintEvent_NostrRecoveryCopyWithImpl<$Res>
+    implements $MultimintEvent_NostrRecoveryCopyWith<$Res> {
+  _$MultimintEvent_NostrRecoveryCopyWithImpl(this._self, this._then);
+
+  final MultimintEvent_NostrRecovery _self;
+  final $Res Function(MultimintEvent_NostrRecovery) _then;
+
+/// Create a copy of MultimintEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? field0 = null,Object? field1 = null,}) {
+  return _then(MultimintEvent_NostrRecovery(
+null == field0 ? _self.field0 : field0 // ignore: cast_nullable_to_non_nullable
+as String,null == field1 ? _self.field1 : field1 // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+/// @nodoc
 mixin _$TransactionKind {
 
 

--- a/lib/scan.dart
+++ b/lib/scan.dart
@@ -208,7 +208,13 @@ class _ScanQRPageState extends State<ScanQRPage> {
           break;
       }
     } catch (e) {
-      AppLogger.instance.warn("No action for scanned text: $text");
+      AppLogger.instance.warn("$text cannot be parsed: $e");
+      ToastService().show(
+        message: "Sorry! That cannot be parsed.",
+        duration: const Duration(seconds: 5),
+        onTap: () {},
+        icon: Icon(Icons.error),
+      );
     }
   }
 

--- a/lib/screens/dashboard.dart
+++ b/lib/screens/dashboard.dart
@@ -76,6 +76,7 @@ class _DashboardState extends State<Dashboard> {
         final recoveredFedId = event.field0;
         final currFederationId = await federationIdToString(federationId: widget.fed.federationId);
         if (currFederationId == recoveredFedId) {
+          if (!mounted) return;
           setState(() => recovering = false);
           _loadBalance();
         }

--- a/rust/ecashapp/src/frb_generated.rs
+++ b/rust/ecashapp/src/frb_generated.rs
@@ -10588,7 +10588,10 @@ impl SseDecode for crate::multimint::MultimintEvent {
             6 => {
                 let mut var_field0 = <String>::sse_decode(deserializer);
                 let mut var_field1 = <u16>::sse_decode(deserializer);
-                return crate::multimint::MultimintEvent::NostrRecovery(var_field0, var_field1);
+                let mut var_field2 = <Option<FederationSelector>>::sse_decode(deserializer);
+                return crate::multimint::MultimintEvent::NostrRecovery(
+                    var_field0, var_field1, var_field2,
+                );
             }
             _ => {
                 unimplemented!("");
@@ -12372,10 +12375,11 @@ impl flutter_rust_bridge::IntoDart for crate::multimint::MultimintEvent {
             crate::multimint::MultimintEvent::Ecash(field0) => {
                 [5.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
-            crate::multimint::MultimintEvent::NostrRecovery(field0, field1) => [
+            crate::multimint::MultimintEvent::NostrRecovery(field0, field1, field2) => [
                 6.into_dart(),
                 field0.into_into_dart().into_dart(),
                 field1.into_into_dart().into_dart(),
+                field2.into_into_dart().into_dart(),
             ]
             .into_dart(),
             _ => {
@@ -13439,10 +13443,11 @@ impl SseEncode for crate::multimint::MultimintEvent {
                 <i32>::sse_encode(5, serializer);
                 <(FederationId, u64)>::sse_encode(field0, serializer);
             }
-            crate::multimint::MultimintEvent::NostrRecovery(field0, field1) => {
+            crate::multimint::MultimintEvent::NostrRecovery(field0, field1, field2) => {
                 <i32>::sse_encode(6, serializer);
                 <String>::sse_encode(field0, serializer);
                 <u16>::sse_encode(field1, serializer);
+                <Option<FederationSelector>>::sse_encode(field2, serializer);
             }
             _ => {
                 unimplemented!("");

--- a/rust/ecashapp/src/frb_generated.rs
+++ b/rust/ecashapp/src/frb_generated.rs
@@ -10585,6 +10585,11 @@ impl SseDecode for crate::multimint::MultimintEvent {
                 let mut var_field0 = <(FederationId, u64)>::sse_decode(deserializer);
                 return crate::multimint::MultimintEvent::Ecash(var_field0);
             }
+            6 => {
+                let mut var_field0 = <String>::sse_decode(deserializer);
+                let mut var_field1 = <u16>::sse_decode(deserializer);
+                return crate::multimint::MultimintEvent::NostrRecovery(var_field0, var_field1);
+            }
             _ => {
                 unimplemented!("");
             }
@@ -12367,6 +12372,12 @@ impl flutter_rust_bridge::IntoDart for crate::multimint::MultimintEvent {
             crate::multimint::MultimintEvent::Ecash(field0) => {
                 [5.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
+            crate::multimint::MultimintEvent::NostrRecovery(field0, field1) => [
+                6.into_dart(),
+                field0.into_into_dart().into_dart(),
+                field1.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
             _ => {
                 unimplemented!("");
             }
@@ -13427,6 +13438,11 @@ impl SseEncode for crate::multimint::MultimintEvent {
             crate::multimint::MultimintEvent::Ecash(field0) => {
                 <i32>::sse_encode(5, serializer);
                 <(FederationId, u64)>::sse_encode(field0, serializer);
+            }
+            crate::multimint::MultimintEvent::NostrRecovery(field0, field1) => {
+                <i32>::sse_encode(6, serializer);
+                <String>::sse_encode(field0, serializer);
+                <u16>::sse_encode(field1, serializer);
             }
             _ => {
                 unimplemented!("");

--- a/rust/ecashapp/src/multimint.rs
+++ b/rust/ecashapp/src/multimint.rs
@@ -55,11 +55,11 @@ use lightning_invoice::{Bolt11Invoice, Description};
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_json::{from_value, json};
-use tokio::sync::RwLock;
 use tokio::{
     sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
     time::Instant,
 };
+use tokio::{sync::RwLock, time::timeout};
 
 use crate::{
     anyhow,
@@ -274,6 +274,7 @@ pub enum MultimintEvent {
     RecoveryDone(String),
     RecoveryProgress(String, u16, u32, u32),
     Ecash((FederationId, u64)),
+    NostrRecovery(String, u16),
 }
 
 #[derive(Clone, Eq, PartialEq, Serialize, Debug)]
@@ -3251,24 +3252,58 @@ impl Multimint {
 
     pub async fn rejoin_from_backup_invites(&mut self, backup_invite_codes: Vec<String>) {
         let mut already_joined_feds = BTreeSet::new();
+
+        info_to_flutter(format!(
+            "Starting to re-join federations from Nostr. Number of invite codes: {}",
+            backup_invite_codes.len()
+        ))
+        .await;
         for invite in backup_invite_codes {
             if let Ok(invite_code) = InviteCode::from_str(&invite) {
-                if !already_joined_feds.contains(&invite_code.federation_id()) {
-                    if let Err(e) = self.join_federation(invite.clone(), true).await {
-                        error_to_flutter(format!(
-                            "Rejoining federation {} with invite code {} failed {}",
-                            invite_code.federation_id(),
-                            invite,
-                            e
+                let fed_id = invite_code.federation_id();
+
+                if !already_joined_feds.contains(&fed_id) {
+                    get_event_bus()
+                        .publish(MultimintEvent::NostrRecovery(
+                            invite_code.federation_id().to_string(),
+                            invite_code.peer().into(),
                         ))
                         .await;
-                    } else {
-                        already_joined_feds.insert(invite_code.federation_id());
-                        info_to_flutter(format!(
-                            "Successfully rejoined {} after recovery",
-                            invite_code.federation_id()
-                        ))
-                        .await;
+
+                    info_to_flutter(format!(
+                        "Rejoining: {} peer: {}",
+                        invite_code.federation_id(),
+                        invite_code.peer()
+                    ))
+                    .await;
+                    match timeout(
+                        Duration::from_secs(30),
+                        self.join_federation(invite.clone(), true),
+                    )
+                    .await
+                    {
+                        Ok(Ok(_)) => {
+                            already_joined_feds.insert(fed_id);
+                            info_to_flutter(format!(
+                                "Successfully rejoined {} after recovery",
+                                fed_id
+                            ))
+                            .await;
+                        }
+                        Ok(Err(e)) => {
+                            error_to_flutter(format!(
+                                "Rejoining federation {} with invite code {} failed: {}",
+                                fed_id, invite, e
+                            ))
+                            .await;
+                        }
+                        Err(_) => {
+                            error_to_flutter(format!(
+                                "Rejoining federation {} with invite code {} timed out",
+                                fed_id, invite
+                            ))
+                            .await;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
During recovery, while joining the federations, it is a bit confusing what is happening. This PR changes the UI to add a status message and a nice toast when successfully re-joining a federation.