### PR TITLE
fix: remove splash delay

### DIFF
--- a/lib/splash.dart
+++ b/lib/splash.dart
@@ -39,11 +39,9 @@ class _SplashState extends State<Splash> {
       screen = CreateWallet(dir: widget.dir);
     }
 
-    Future.delayed(const Duration(seconds: 2), () async {
-      Navigator.of(
-        context,
-      ).pushReplacement(MaterialPageRoute(builder: (_) => screen));
-    });
+    Navigator.of(
+      context,
+    ).pushReplacement(MaterialPageRoute(builder: (_) => screen));
   }
 
   @override


### PR DESCRIPTION
Fixes: https://github.com/fedimint/e-cash-app/issues/139

We don't need to delay the splash screen, otherwise ours and Flutter's are both shown which is a bit awkward. 