### PR TITLE
feat: add sat symbol

### DIFF
--- a/lib/db.dart
+++ b/lib/db.dart
@@ -63,4 +63,4 @@ abstract class LightningAddressKey implements RustOpaqueInterface {
   set federationId(FederationId federationId);
 }
 
-enum DisplaySetting { bip177, sats, nothing }
+enum DisplaySetting { bip177, sats, nothing, symbol }

--- a/lib/setttings.dart
+++ b/lib/setttings.dart
@@ -225,7 +225,7 @@ void _showDisplaySettingDialog(BuildContext context) {
               mainAxisSize: MainAxisSize.min,
               children: [
                 RadioListTile<DisplaySetting>(
-                  title: const Text('Bip177 (₿1,234)'),
+                  title: const Text('BIP177 (₿1,234)'),
                   value: DisplaySetting.bip177,
                   groupValue: selected,
                   onChanged: (value) => setState(() => selected = value!),
@@ -233,6 +233,12 @@ void _showDisplaySettingDialog(BuildContext context) {
                 RadioListTile<DisplaySetting>(
                   title: const Text('Sats are the Standard (1,234 sats)'),
                   value: DisplaySetting.sats,
+                  groupValue: selected,
+                  onChanged: (value) => setState(() => selected = value!),
+                ),
+                RadioListTile<DisplaySetting>(
+                  title: const Text('Sat Symbol (1,234丰)'),
+                  value: DisplaySetting.symbol,
                   groupValue: selected,
                   onChanged: (value) => setState(() => selected = value!),
                 ),

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -120,6 +120,7 @@ String formatBalance(BigInt? msats, bool showMsats) {
       DisplaySetting.bip177 => showMsats ? '₿0.000' : '₿0',
       DisplaySetting.sats => showMsats ? '0.000 sats' : '0 sats',
       DisplaySetting.nothing => showMsats ? '0.000' : '0',
+      DisplaySetting.symbol => showMsats ? '0.000丰' : '0丰',
     };
   }
 
@@ -131,6 +132,7 @@ String formatBalance(BigInt? msats, bool showMsats) {
       DisplaySetting.bip177 => '₿$formatted',
       DisplaySetting.sats => '$formatted sats',
       DisplaySetting.nothing => formatted,
+      DisplaySetting.symbol => '$formatted丰',
     };
   } else {
     final sats = msats.toSats;
@@ -140,6 +142,7 @@ String formatBalance(BigInt? msats, bool showMsats) {
       DisplaySetting.bip177 => '₿$formatted',
       DisplaySetting.sats => '$formatted sats',
       DisplaySetting.nothing => formatted,
+      DisplaySetting.symbol => '$formatted丰',
     };
   }
 }

--- a/rust/ecashapp/src/db.rs
+++ b/rust/ecashapp/src/db.rs
@@ -162,6 +162,7 @@ pub enum DisplaySetting {
     Bip177,
     Sats,
     Nothing,
+    Symbol,
 }
 
 #[derive(Debug, Encodable, Decodable)]

--- a/rust/ecashapp/src/frb_generated.rs
+++ b/rust/ecashapp/src/frb_generated.rs
@@ -10421,6 +10421,7 @@ impl SseDecode for crate::db::DisplaySetting {
             0 => crate::db::DisplaySetting::Bip177,
             1 => crate::db::DisplaySetting::Sats,
             2 => crate::db::DisplaySetting::Nothing,
+            3 => crate::db::DisplaySetting::Symbol,
             _ => unreachable!("Invalid variant for DisplaySetting: {}", inner),
         };
     }
@@ -12351,6 +12352,7 @@ impl flutter_rust_bridge::IntoDart for crate::db::DisplaySetting {
             Self::Bip177 => 0.into_dart(),
             Self::Sats => 1.into_dart(),
             Self::Nothing => 2.into_dart(),
+            Self::Symbol => 3.into_dart(),
             _ => unreachable!(),
         }
     }
@@ -13346,6 +13348,7 @@ impl SseEncode for crate::db::DisplaySetting {
                 crate::db::DisplaySetting::Bip177 => 0,
                 crate::db::DisplaySetting::Sats => 1,
                 crate::db::DisplaySetting::Nothing => 2,
+                crate::db::DisplaySetting::Symbol => 3,
                 _ => {
                     unimplemented!("");
                 }


### PR DESCRIPTION
Fixes: https://github.com/fedimint/e-cash-app/issues/138

Given that our icon is the sat symbol we might as well support the Display setting to use the sat symbol. I hate that there's no one sat symbol :/