### PR TITLE
feat: change ln address domain to ecash.love

### DIFF
--- a/lib/fed_preview.dart
+++ b/lib/fed_preview.dart
@@ -79,8 +79,8 @@ class _FederationPreviewState extends State<FederationPreview> {
   }
 
   Future<void> _claimLnAddress(FederationSelector fed) async {
-    String defaultRecurringd = "https://recurringd.mplsfed.xyz";
-    String defaultLnAddress = "https://lnaddress.mplsfed.xyz";
+    String defaultLnAddress = "https://ecash.love";
+    String defaultRecurringd = "https://lnurl.ecash.love";
     try {
       await claimRandomLnAddress(
         federationId: fed.federationId,

--- a/lib/ln_address.dart
+++ b/lib/ln_address.dart
@@ -23,8 +23,8 @@ class LightningAddressScreen extends StatefulWidget {
 }
 
 class _LightningAddressScreenState extends State<LightningAddressScreen> {
-  String _lnAddressApi = "https://lnaddress.mplsfed.xyz";
-  String _recurringdApi = "https://recurringd.mplsfed.xyz";
+  String _lnAddressApi = "https://ecash.love";
+  String _recurringdApi = "https://lnurl.ecash.love";
   bool _loading = true;
   FederationSelector? _selectedFederation;
 


### PR DESCRIPTION
Changing default recurringd and ln address server to `ecash.love`. Can still be set in the meta.