### PR TITLE
fix: use tx outpoint instead of txid

### DIFF
--- a/lib/frb_generated.dart
+++ b/lib/frb_generated.dart
@@ -8687,7 +8687,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return AwaitingConfsEvent(
       amount: dco_decode_u_64(arr[0]),
-      txid: dco_decode_String(arr[1]),
+      outpoint: dco_decode_String(arr[1]),
       blockHeight: dco_decode_u_64(arr[2]),
       needed: dco_decode_u_64(arr[3]),
     );
@@ -8809,7 +8809,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return ClaimedEvent(
       amount: dco_decode_u_64(arr[0]),
-      txid: dco_decode_String(arr[1]),
+      outpoint: dco_decode_String(arr[1]),
     );
   }
 
@@ -8821,7 +8821,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return ConfirmedEvent(
       amount: dco_decode_u_64(arr[0]),
-      txid: dco_decode_String(arr[1]),
+      outpoint: dco_decode_String(arr[1]),
     );
   }
 
@@ -9061,7 +9061,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return MempoolEvent(
       amount: dco_decode_u_64(arr[0]),
-      txid: dco_decode_String(arr[1]),
+      outpoint: dco_decode_String(arr[1]),
     );
   }
 
@@ -10458,12 +10458,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_amount = sse_decode_u_64(deserializer);
-    var var_txid = sse_decode_String(deserializer);
+    var var_outpoint = sse_decode_String(deserializer);
     var var_blockHeight = sse_decode_u_64(deserializer);
     var var_needed = sse_decode_u_64(deserializer);
     return AwaitingConfsEvent(
       amount: var_amount,
-      txid: var_txid,
+      outpoint: var_outpoint,
       blockHeight: var_blockHeight,
       needed: var_needed,
     );
@@ -10599,16 +10599,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ClaimedEvent sse_decode_claimed_event(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_amount = sse_decode_u_64(deserializer);
-    var var_txid = sse_decode_String(deserializer);
-    return ClaimedEvent(amount: var_amount, txid: var_txid);
+    var var_outpoint = sse_decode_String(deserializer);
+    return ClaimedEvent(amount: var_amount, outpoint: var_outpoint);
   }
 
   @protected
   ConfirmedEvent sse_decode_confirmed_event(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_amount = sse_decode_u_64(deserializer);
-    var var_txid = sse_decode_String(deserializer);
-    return ConfirmedEvent(amount: var_amount, txid: var_txid);
+    var var_outpoint = sse_decode_String(deserializer);
+    return ConfirmedEvent(amount: var_amount, outpoint: var_outpoint);
   }
 
   @protected
@@ -10931,8 +10931,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MempoolEvent sse_decode_mempool_event(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_amount = sse_decode_u_64(deserializer);
-    var var_txid = sse_decode_String(deserializer);
-    return MempoolEvent(amount: var_amount, txid: var_txid);
+    var var_outpoint = sse_decode_String(deserializer);
+    return MempoolEvent(amount: var_amount, outpoint: var_outpoint);
   }
 
   @protected
@@ -12415,7 +12415,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_64(self.amount, serializer);
-    sse_encode_String(self.txid, serializer);
+    sse_encode_String(self.outpoint, serializer);
     sse_encode_u_64(self.blockHeight, serializer);
     sse_encode_u_64(self.needed, serializer);
   }
@@ -12568,7 +12568,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_claimed_event(ClaimedEvent self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_64(self.amount, serializer);
-    sse_encode_String(self.txid, serializer);
+    sse_encode_String(self.outpoint, serializer);
   }
 
   @protected
@@ -12578,7 +12578,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_64(self.amount, serializer);
-    sse_encode_String(self.txid, serializer);
+    sse_encode_String(self.outpoint, serializer);
   }
 
   @protected
@@ -12859,7 +12859,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_mempool_event(MempoolEvent self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_64(self.amount, serializer);
-    sse_encode_String(self.txid, serializer);
+    sse_encode_String(self.outpoint, serializer);
   }
 
   @protected

--- a/lib/multimint.dart
+++ b/lib/multimint.dart
@@ -308,20 +308,23 @@ abstract class WithdrawFeesResponse implements RustOpaqueInterface {
 
 class AwaitingConfsEvent {
   final BigInt amount;
-  final String txid;
+  final String outpoint;
   final BigInt blockHeight;
   final BigInt needed;
 
   const AwaitingConfsEvent({
     required this.amount,
-    required this.txid,
+    required this.outpoint,
     required this.blockHeight,
     required this.needed,
   });
 
   @override
   int get hashCode =>
-      amount.hashCode ^ txid.hashCode ^ blockHeight.hashCode ^ needed.hashCode;
+      amount.hashCode ^
+      outpoint.hashCode ^
+      blockHeight.hashCode ^
+      needed.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -329,19 +332,19 @@ class AwaitingConfsEvent {
       other is AwaitingConfsEvent &&
           runtimeType == other.runtimeType &&
           amount == other.amount &&
-          txid == other.txid &&
+          outpoint == other.outpoint &&
           blockHeight == other.blockHeight &&
           needed == other.needed;
 }
 
 class ClaimedEvent {
   final BigInt amount;
-  final String txid;
+  final String outpoint;
 
-  const ClaimedEvent({required this.amount, required this.txid});
+  const ClaimedEvent({required this.amount, required this.outpoint});
 
   @override
-  int get hashCode => amount.hashCode ^ txid.hashCode;
+  int get hashCode => amount.hashCode ^ outpoint.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -349,17 +352,17 @@ class ClaimedEvent {
       other is ClaimedEvent &&
           runtimeType == other.runtimeType &&
           amount == other.amount &&
-          txid == other.txid;
+          outpoint == other.outpoint;
 }
 
 class ConfirmedEvent {
   final BigInt amount;
-  final String txid;
+  final String outpoint;
 
-  const ConfirmedEvent({required this.amount, required this.txid});
+  const ConfirmedEvent({required this.amount, required this.outpoint});
 
   @override
-  int get hashCode => amount.hashCode ^ txid.hashCode;
+  int get hashCode => amount.hashCode ^ outpoint.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -367,7 +370,7 @@ class ConfirmedEvent {
       other is ConfirmedEvent &&
           runtimeType == other.runtimeType &&
           amount == other.amount &&
-          txid == other.txid;
+          outpoint == other.outpoint;
 }
 
 @freezed
@@ -495,12 +498,12 @@ enum LogLevel { trace, debug, info, warn, error }
 
 class MempoolEvent {
   final BigInt amount;
-  final String txid;
+  final String outpoint;
 
-  const MempoolEvent({required this.amount, required this.txid});
+  const MempoolEvent({required this.amount, required this.outpoint});
 
   @override
-  int get hashCode => amount.hashCode ^ txid.hashCode;
+  int get hashCode => amount.hashCode ^ outpoint.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -508,7 +511,7 @@ class MempoolEvent {
       other is MempoolEvent &&
           runtimeType == other.runtimeType &&
           amount == other.amount &&
-          txid == other.txid;
+          outpoint == other.outpoint;
 }
 
 @freezed

--- a/lib/widgets/transactions_list.dart
+++ b/lib/widgets/transactions_list.dart
@@ -28,9 +28,11 @@ class TransactionsList extends StatefulWidget {
   _TransactionsListState createState() => _TransactionsListState();
 }
 
+typedef TxOutpoint = String;
+
 class _TransactionsListState extends State<TransactionsList> {
   final List<Transaction> _transactions = [];
-  final Map<String, DepositEventKind> _depositMap = {};
+  final Map<TxOutpoint, DepositEventKind> _depositMap = {};
   bool _isLoading = true;
   bool _hasMore = true;
   Transaction? _lastTransaction;
@@ -69,22 +71,22 @@ class _TransactionsListState extends State<TransactionsList> {
     });
 
     _depositSubscription = depositEvents.listen((e) {
-      String txid;
+      String txOutpoint;
       switch (e) {
         case DepositEventKind_Mempool(field0: final mempoolEvt):
-          txid = mempoolEvt.txid;
+          txOutpoint = mempoolEvt.outpoint;
           break;
         case DepositEventKind_AwaitingConfs(field0: final awaitEvt):
-          txid = awaitEvt.txid;
+          txOutpoint = awaitEvt.outpoint;
           break;
         case DepositEventKind_Confirmed(field0: final confirmedEvt):
-          txid = confirmedEvt.txid;
+          txOutpoint = confirmedEvt.outpoint;
           break;
         case DepositEventKind_Claimed(field0: final claimedEvt):
-          txid = claimedEvt.txid;
+          txOutpoint = claimedEvt.outpoint;
           break;
       }
-      setState(() => _depositMap[txid] = e);
+      setState(() => _depositMap[txOutpoint] = e);
     });
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -396,26 +396,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.1"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -729,10 +729,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.4"
   timing:
     dependency: transitive
     description:
@@ -825,10 +825,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
@@ -894,5 +894,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.7.2 <4.0.0"
   flutter: ">=3.29.0"

--- a/rust/ecashapp/src/frb_generated.rs
+++ b/rust/ecashapp/src/frb_generated.rs
@@ -10382,12 +10382,12 @@ impl SseDecode for crate::multimint::AwaitingConfsEvent {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_amount = <u64>::sse_decode(deserializer);
-        let mut var_txid = <String>::sse_decode(deserializer);
+        let mut var_outpoint = <String>::sse_decode(deserializer);
         let mut var_blockHeight = <u64>::sse_decode(deserializer);
         let mut var_needed = <u64>::sse_decode(deserializer);
         return crate::multimint::AwaitingConfsEvent {
             amount: var_amount,
-            txid: var_txid,
+            outpoint: var_outpoint,
             block_height: var_blockHeight,
             needed: var_needed,
         };
@@ -10405,10 +10405,10 @@ impl SseDecode for crate::multimint::ClaimedEvent {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_amount = <u64>::sse_decode(deserializer);
-        let mut var_txid = <String>::sse_decode(deserializer);
+        let mut var_outpoint = <String>::sse_decode(deserializer);
         return crate::multimint::ClaimedEvent {
             amount: var_amount,
-            txid: var_txid,
+            outpoint: var_outpoint,
         };
     }
 }
@@ -10417,10 +10417,10 @@ impl SseDecode for crate::multimint::ConfirmedEvent {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_amount = <u64>::sse_decode(deserializer);
-        let mut var_txid = <String>::sse_decode(deserializer);
+        let mut var_outpoint = <String>::sse_decode(deserializer);
         return crate::multimint::ConfirmedEvent {
             amount: var_amount,
-            txid: var_txid,
+            outpoint: var_outpoint,
         };
     }
 }
@@ -10756,10 +10756,10 @@ impl SseDecode for crate::multimint::MempoolEvent {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_amount = <u64>::sse_decode(deserializer);
-        let mut var_txid = <String>::sse_decode(deserializer);
+        let mut var_outpoint = <String>::sse_decode(deserializer);
         return crate::multimint::MempoolEvent {
             amount: var_amount,
-            txid: var_txid,
+            outpoint: var_outpoint,
         };
     }
 }
@@ -12300,7 +12300,7 @@ impl flutter_rust_bridge::IntoDart for crate::multimint::AwaitingConfsEvent {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
             self.amount.into_into_dart().into_dart(),
-            self.txid.into_into_dart().into_dart(),
+            self.outpoint.into_into_dart().into_dart(),
             self.block_height.into_into_dart().into_dart(),
             self.needed.into_into_dart().into_dart(),
         ]
@@ -12323,7 +12323,7 @@ impl flutter_rust_bridge::IntoDart for crate::multimint::ClaimedEvent {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
             self.amount.into_into_dart().into_dart(),
-            self.txid.into_into_dart().into_dart(),
+            self.outpoint.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -12344,7 +12344,7 @@ impl flutter_rust_bridge::IntoDart for crate::multimint::ConfirmedEvent {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
             self.amount.into_into_dart().into_dart(),
-            self.txid.into_into_dart().into_dart(),
+            self.outpoint.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -12571,7 +12571,7 @@ impl flutter_rust_bridge::IntoDart for crate::multimint::MempoolEvent {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
             self.amount.into_into_dart().into_dart(),
-            self.txid.into_into_dart().into_dart(),
+            self.outpoint.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -13335,7 +13335,7 @@ impl SseEncode for crate::multimint::AwaitingConfsEvent {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u64>::sse_encode(self.amount, serializer);
-        <String>::sse_encode(self.txid, serializer);
+        <String>::sse_encode(self.outpoint, serializer);
         <u64>::sse_encode(self.block_height, serializer);
         <u64>::sse_encode(self.needed, serializer);
     }
@@ -13352,7 +13352,7 @@ impl SseEncode for crate::multimint::ClaimedEvent {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u64>::sse_encode(self.amount, serializer);
-        <String>::sse_encode(self.txid, serializer);
+        <String>::sse_encode(self.outpoint, serializer);
     }
 }
 
@@ -13360,7 +13360,7 @@ impl SseEncode for crate::multimint::ConfirmedEvent {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u64>::sse_encode(self.amount, serializer);
-        <String>::sse_encode(self.txid, serializer);
+        <String>::sse_encode(self.outpoint, serializer);
     }
 }
 
@@ -13654,7 +13654,7 @@ impl SseEncode for crate::multimint::MempoolEvent {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u64>::sse_encode(self.amount, serializer);
-        <String>::sse_encode(self.txid, serializer);
+        <String>::sse_encode(self.outpoint, serializer);
     }
 }
 

--- a/rust/ecashapp/src/multimint.rs
+++ b/rust/ecashapp/src/multimint.rs
@@ -218,13 +218,13 @@ impl fmt::Display for ClientType {
 #[derive(Clone, Eq, PartialEq, Serialize, Debug)]
 pub struct MempoolEvent {
     pub amount: u64,
-    pub txid: String,
+    pub outpoint: String,
 }
 
 #[derive(Clone, Eq, PartialEq, Serialize, Debug)]
 pub struct AwaitingConfsEvent {
     pub amount: u64,
-    pub txid: String,
+    pub outpoint: String,
     pub block_height: u64,
     pub needed: u64,
 }
@@ -232,13 +232,13 @@ pub struct AwaitingConfsEvent {
 #[derive(Clone, Eq, PartialEq, Serialize, Debug)]
 pub struct ConfirmedEvent {
     pub amount: u64,
-    pub txid: String,
+    pub outpoint: String,
 }
 
 #[derive(Clone, Eq, PartialEq, Serialize, Debug)]
 pub struct ClaimedEvent {
     pub amount: u64,
-    pub txid: String,
+    pub outpoint: String,
 }
 
 #[derive(Clone, Eq, PartialEq, Serialize, Debug)]
@@ -536,7 +536,7 @@ impl Multimint {
                         federation_id,
                         DepositEventKind::Mempool(MempoolEvent {
                             amount: Amount::from_sats(btc_deposited.to_sat()).msats,
-                            txid: btc_out_point.txid.to_string(),
+                            outpoint: btc_out_point.to_string(),
                         }),
                     ));
 
@@ -599,7 +599,7 @@ impl Multimint {
                             federation_id,
                             DepositEventKind::AwaitingConfs(AwaitingConfsEvent {
                                 amount: Amount::from_sats(btc_deposited.to_sat()).msats,
-                                txid: btc_out_point.txid.to_string(),
+                                outpoint: btc_out_point.to_string(),
                                 block_height: tx_height,
                                 needed,
                             }),
@@ -632,7 +632,7 @@ impl Multimint {
                         federation_id,
                         DepositEventKind::Confirmed(ConfirmedEvent {
                             amount: Amount::from_sats(btc_deposited.to_sat()).msats,
-                            txid: btc_out_point.txid.to_string(),
+                            outpoint: btc_out_point.to_string(),
                         }),
                     ));
 
@@ -646,7 +646,7 @@ impl Multimint {
                         federation_id,
                         DepositEventKind::Claimed(ClaimedEvent {
                             amount: Amount::from_sats(btc_deposited.to_sat()).msats,
-                            txid: btc_out_point.txid.to_string(),
+                            outpoint: btc_out_point.to_string(),
                         }),
                     ));
 


### PR DESCRIPTION
In the UI, we track pending deposits grouped by txid. This is not correct, since it's possible for the deposit transaction to have multiple outputs going to the same deposit address. The fix is simply grouping by outpoint instead of txid.