### PR TITLE
fix: stop RFQ timer and disable recalculate fees on withdrawal

### DIFF
--- a/lib/onchain_send.dart
+++ b/lib/onchain_send.dart
@@ -173,6 +173,7 @@ class _OnchainSendState extends State<OnchainSend> {
       return;
     }
 
+    _quoteTimer?.cancel();
     setState(() => _withdrawing = true);
 
     try {
@@ -390,7 +391,10 @@ class _OnchainSendState extends State<OnchainSend> {
                   children: [
                     Expanded(
                       child: TextButton(
-                        onPressed: _loadingFees ? null : _calculateFees,
+                        onPressed:
+                            (_loadingFees || _withdrawing)
+                                ? null
+                                : _calculateFees,
                         child:
                             _loadingFees
                                 ? const Row(


### PR DESCRIPTION
I noticed that after clicking `Confirm Withdrawal`, the timer kept on going and the `Recalculate Fees` button was still clickable. I tried this on our Mutinynet Iroh federation and the withdrawl actually took so long that the timer hit and the fees were re-calculated.

We should just cancel the timer after clicking `Confirm Withdrawal`