### PR TITLE
chore: remove rust targets that are not arm64

### DIFF
--- a/.github/actions/android-build/action.yml
+++ b/.github/actions/android-build/action.yml
@@ -80,7 +80,7 @@ runs:
       uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
+        targets: aarch64-linux-android
 
     - name: Set up Android NDK
       uses: nttld/setup-ndk@v1


### PR DESCRIPTION
Fixes: https://github.com/fedimint/e-cash-app/issues/201

As far as I can tell, the rest of our build process is already `arm64` specific.