### PR TITLE
chore: add workflow dispatch to android debug workflow

### DIFF
--- a/.github/workflows/android-debug.yml
+++ b/.github/workflows/android-debug.yml
@@ -1,6 +1,7 @@
 name: Android Debug
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
In order to add our android debug workflow as a required step, we need to have the workflow complete a run vs `master`. Adding the dispatch will allow us to trigger the workflow, then we can add it as a required step in PRs.